### PR TITLE
Refactored duplicate model validation checks to custom action filter.

### DIFF
--- a/PaymentGatewayApi/Controllers/PaymentsController.cs
+++ b/PaymentGatewayApi/Controllers/PaymentsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using PaymentGatewayApi.Models.CustomAttributes.ActionFilters;
 using PaymentGatewayApi.Models.RequestEntities;
 using PaymentGatewayApi.Models.ResponseEntities;
 using PaymentGatewayApi.Services;
@@ -22,17 +23,9 @@ namespace PaymentGatewayApi.Controllers
         }
 
         [HttpPost]
+        [ModelValidation]
         public async Task<IActionResult> ProcessPayment([FromBody] ProcessPaymentRequestDto paymentDetails)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(new ResponseBaseDto() 
-                {
-                    StatusCode = HttpStatusCode.BadRequest,
-                    Data = new ValidationErrorResponse(ModelState)
-                });
-            }
-
             var responseData = await this._paymentsProcessingService.ProcessPayment(paymentDetails);
 
             return Ok(new ResponseBaseDto()
@@ -43,17 +36,9 @@ namespace PaymentGatewayApi.Controllers
         }
 
         [HttpGet("{transactionid}")]
+        [ModelValidation]
         public async Task<IActionResult> RetrievePayments(RetrievePaymentsRequestDto model)
         {
-            if(!ModelState.IsValid)
-            {
-                return BadRequest(new ResponseBaseDto()
-                {
-                    StatusCode = HttpStatusCode.BadRequest,
-                    Data = new ValidationErrorResponse(ModelState)
-                });
-            }
-
             var responseData = await this._paymentsRetrievalService.RetrievePayments(model);
 
             return Ok(new ResponseBaseDto()

--- a/PaymentGatewayApi/Models/CustomAttributes/ActionFilters/ModelValidationAttribute.cs
+++ b/PaymentGatewayApi/Models/CustomAttributes/ActionFilters/ModelValidationAttribute.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using PaymentGatewayApi.Models.ResponseEntities;
+using System.Net;
+
+namespace PaymentGatewayApi.Models.CustomAttributes.ActionFilters
+{
+    public class ModelValidationAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (!context.ModelState.IsValid)
+            {
+                context.Result = new BadRequestObjectResult(new ResponseBaseDto()
+                {
+                    StatusCode = HttpStatusCode.BadRequest,
+                    Data = new ValidationErrorResponse(context.ModelState)
+                });
+            }
+        }
+    }
+}

--- a/PaymentGatewayApi/Startup.cs
+++ b/PaymentGatewayApi/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using PaymentGatewayApi.Mappers;
 using PaymentGatewayApi.Middleware;
+using PaymentGatewayApi.Models.CustomAttributes.ActionFilters;
 using PaymentGatewayApi.Services;
 using PaymentGatewayApi.Services.Banking;
 using System;
@@ -41,6 +42,7 @@ namespace PaymentGatewayApi
             });
             services.AddControllers();
 
+            services.AddScoped<ModelValidationAttribute>();
             services.AddTransient<IPaymentsProcessingService, DefaultPaymentsProcessingService>();
             services.AddTransient<IPaymentsRetrievalService, DefaultPaymentsRetrievalService>();
             services.AddTransient<IDtoMapper, DtoMapper>();

--- a/PaymentGatewayApiTests/Controllers/PaymentControllerTests.cs
+++ b/PaymentGatewayApiTests/Controllers/PaymentControllerTests.cs
@@ -30,7 +30,7 @@ namespace PaymentGatewayApiTests.Controllers
         }
 
         [Test]
-        public async Task ProcessPaymentShouldReturn200ForValidModelState()
+        public async Task ProcessPaymentShouldReturn200()
         {
             //Arrange
             var model = new ProcessPaymentRequestDto();
@@ -67,43 +67,7 @@ namespace PaymentGatewayApiTests.Controllers
         }
 
         [Test]
-        public void ProcessPaymentShouldReturn400ForInvalidModelState()
-        {
-            //Arrange
-            var model = new ProcessPaymentRequestDto();
-            this._controller.ModelState.AddModelError("ExpirationMonth", Resources.Validation_ExpirationMonth);
-
-            //Act
-            var result = this._controller.ProcessPayment(model).Result;
-
-            //Assert
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<BadRequestObjectResult>(result);
-
-            var resultAsBadRequestObject = result as BadRequestObjectResult;
-            Assert.IsTrue(resultAsBadRequestObject.StatusCode == 400);
-            Assert.IsNotNull(resultAsBadRequestObject.Value);
-            Assert.IsInstanceOf<ResponseBaseDto>(resultAsBadRequestObject.Value);
-
-            var resultValue = resultAsBadRequestObject.Value as ResponseBaseDto;
-            Assert.IsTrue(resultValue.StatusCode == HttpStatusCode.BadRequest);
-            Assert.IsNotNull(resultValue.Data);
-            Assert.IsInstanceOf<ValidationErrorResponse>(resultValue.Data);
-
-            var resultError = resultValue.Data as ValidationErrorResponse;
-            Assert.IsTrue(resultError.ErrorMessage == Resources.ErrorMessage_Validation);
-            Assert.IsTrue(resultError.ErrorDescription == Resources.ErrorDescription_Validation);
-            Assert.IsTrue(resultError.ErrorCode == Resources.ErrorCode_Validation);
-            Assert.IsNotNull(resultError.ValidationErrors);
-            Assert.IsTrue(resultError.ValidationErrors.Count == 1);
-            Assert.IsTrue(resultError.ValidationErrors[0].FieldName == "ExpirationMonth");
-            Assert.IsNotNull(resultError.ValidationErrors[0].ErrorMessages);
-            Assert.IsTrue(resultError.ValidationErrors[0].ErrorMessages.Length == 1);
-            Assert.IsTrue(resultError.ValidationErrors[0].ErrorMessages[0] == Resources.Validation_ExpirationMonth);
-        }
-
-        [Test]
-        public async Task RetrievePaymentsShouldReturn200ForValidModelState()
+        public async Task RetrievePaymentsShouldReturn200()
         {
             //Arrange
             var model = new RetrievePaymentsRequestDto();
@@ -161,42 +125,6 @@ namespace PaymentGatewayApiTests.Controllers
             Assert.AreEqual(serviceResponse.Payments[0].CardType, resultPayment.CardType);
             Assert.AreEqual(serviceResponse.Payments[0].ExpirationMonth, resultPayment.ExpirationMonth);
             Assert.AreEqual(serviceResponse.Payments[0].ExpirationYear, resultPayment.ExpirationYear);
-        }
-
-        [Test]
-        public void RetrievePaymentShouldReturn400ForInvalidModelState()
-        {
-            //Arrange
-            var model = new ProcessPaymentRequestDto();
-            this._controller.ModelState.AddModelError("TransactionId", Resources.Validation_TransactionId);
-
-            //Act
-            var result = this._controller.ProcessPayment(model).Result;
-
-            //Assert
-            Assert.IsNotNull(result);
-            Assert.IsInstanceOf<BadRequestObjectResult>(result);
-
-            var resultAsBadRequestObject = result as BadRequestObjectResult;
-            Assert.IsTrue(resultAsBadRequestObject.StatusCode == 400);
-            Assert.IsNotNull(resultAsBadRequestObject.Value);
-            Assert.IsInstanceOf<ResponseBaseDto>(resultAsBadRequestObject.Value);
-
-            var resultValue = resultAsBadRequestObject.Value as ResponseBaseDto;
-            Assert.IsTrue(resultValue.StatusCode == HttpStatusCode.BadRequest);
-            Assert.IsNotNull(resultValue.Data);
-            Assert.IsInstanceOf<ValidationErrorResponse>(resultValue.Data);
-
-            var resultError = resultValue.Data as ValidationErrorResponse;
-            Assert.IsTrue(resultError.ErrorMessage == Resources.ErrorMessage_Validation);
-            Assert.IsTrue(resultError.ErrorDescription == Resources.ErrorDescription_Validation);
-            Assert.IsTrue(resultError.ErrorCode == Resources.ErrorCode_Validation);
-            Assert.IsNotNull(resultError.ValidationErrors);
-            Assert.IsTrue(resultError.ValidationErrors.Count == 1);
-            Assert.IsTrue(resultError.ValidationErrors[0].FieldName == "TransactionId");
-            Assert.IsNotNull(resultError.ValidationErrors[0].ErrorMessages);
-            Assert.IsTrue(resultError.ValidationErrors[0].ErrorMessages.Length == 1);
-            Assert.IsTrue(resultError.ValidationErrors[0].ErrorMessages[0] == Resources.Validation_TransactionId);
         }
     }
 }

--- a/PaymentGatewayApiTests/Models/CustomAttributes/ActionFilters/ModelValidationAttributeTests.cs
+++ b/PaymentGatewayApiTests/Models/CustomAttributes/ActionFilters/ModelValidationAttributeTests.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Moq;
+using NUnit.Framework;
+using PaymentGatewayApi.Models.CustomAttributes.ActionFilters;
+using PaymentGatewayApi.Models.ResponseEntities;
+using PaymentGatewayApi.Resources;
+using System.Collections.Generic;
+using System.Net;
+
+namespace PaymentGatewayApiTests.Models.CustomAttributes.ActionFilters
+{
+    [TestFixture]
+    public class ModelValidationAttributeTests
+    {
+        [Test]
+        public void FailedModelValidationShouldResultInBadRequestStatus()
+        {
+            var modelState = new ModelStateDictionary();
+            modelState.AddModelError("fieldName", "error");
+
+            var httpContext = new DefaultHttpContext();
+
+            var actionExecutingContext = new ActionExecutingContext(
+                new ActionContext(
+                    httpContext: httpContext,
+                    routeData: new Microsoft.AspNetCore.Routing.RouteData(),
+                    actionDescriptor: new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor(),
+                    modelState: modelState),
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                new Mock<Controller>().Object);
+
+            var actionFilter = new ModelValidationAttribute();
+
+            //Act
+            actionFilter.OnActionExecuting(actionExecutingContext);
+
+            //Assert
+            Assert.IsNotNull(actionExecutingContext.Result);
+            Assert.IsInstanceOf<BadRequestObjectResult>(actionExecutingContext.Result);
+
+            var resultAsBadRequestObject = actionExecutingContext.Result as BadRequestObjectResult;
+            Assert.IsTrue(resultAsBadRequestObject.StatusCode == 400);
+            Assert.IsNotNull(resultAsBadRequestObject.Value);
+            Assert.IsInstanceOf<ResponseBaseDto>(resultAsBadRequestObject.Value);
+
+            var resultValue = resultAsBadRequestObject.Value as ResponseBaseDto;
+            Assert.IsTrue(resultValue.StatusCode == HttpStatusCode.BadRequest);
+            Assert.IsNotNull(resultValue.Data);
+            Assert.IsInstanceOf<ValidationErrorResponse>(resultValue.Data);
+
+            var resultError = resultValue.Data as ValidationErrorResponse;
+            Assert.IsTrue(resultError.ErrorMessage == Resources.ErrorMessage_Validation);
+            Assert.IsTrue(resultError.ErrorDescription == Resources.ErrorDescription_Validation);
+            Assert.IsTrue(resultError.ErrorCode == Resources.ErrorCode_Validation);
+            Assert.IsNotNull(resultError.ValidationErrors);
+            Assert.IsTrue(resultError.ValidationErrors.Count == 1);
+            Assert.IsTrue(resultError.ValidationErrors[0].FieldName == "fieldName");
+            Assert.IsNotNull(resultError.ValidationErrors[0].ErrorMessages);
+            Assert.IsTrue(resultError.ValidationErrors[0].ErrorMessages.Length == 1);
+            Assert.IsTrue(resultError.ValidationErrors[0].ErrorMessages[0] == "error");
+        }
+
+        [Test]
+        public void SuccessfulModelValidationShouldNotUpdateContextResult()
+        {
+            var modelState = new ModelStateDictionary();
+
+            var httpContext = new DefaultHttpContext();
+
+            var actionExecutingContext = new ActionExecutingContext(
+                new ActionContext(
+                    httpContext: httpContext,
+                    routeData: new Microsoft.AspNetCore.Routing.RouteData(),
+                    actionDescriptor: new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor(),
+                    modelState: modelState),
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                new Mock<Controller>().Object);
+
+            var actionFilter = new ModelValidationAttribute();
+
+            //Act
+            actionFilter.OnActionExecuting(actionExecutingContext);
+
+            //Assert
+            Assert.IsNull(actionExecutingContext.Result);
+        }
+    }
+}


### PR DESCRIPTION
In the interest of keeping the action methods more clean and simple, I've moved the duplicate ModelState.IsValid checks to a custom action filter and decorated them both with it.