### PR TITLE
Updated references to "Authentication" header to "Authorization" header.

### DIFF
--- a/APIAuthentication/Handlers/BasicAuthenticationHandler.cs
+++ b/APIAuthentication/Handlers/BasicAuthenticationHandler.cs
@@ -37,8 +37,8 @@ namespace APIAuthentication.Handlers
             {
                 //The thrown HTTPExceptions in this class will be caught, logged and handled within the global exception middleware.
                 throw new HttpException(HttpStatusCode.Unauthorized, 
-                                        Resources.ErrorCode_UnauthenticatedMissingAuthenticationHeader, 
-                                        Resources.ErrorMessage_UnauthenticatedMissingAuthenticationHeader);
+                                        Resources.ErrorCode_UnauthenticatedMissingAuthorisationHeader, 
+                                        Resources.ErrorMessage_UnauthenticatedMissingAuthorisationHeader);
             }
 
             User user;
@@ -54,8 +54,8 @@ namespace APIAuthentication.Handlers
             catch
             {
                 throw new HttpException(HttpStatusCode.Unauthorized,
-                        Resources.ErrorCode_UnauthenticatedInvalidAuthenticationHeader,
-                        Resources.ErrorMessage_UnauthenticatedInvalidAuthenticationHeader);
+                        Resources.ErrorCode_UnauthenticatedInvalidAuthorisationHeader,
+                        Resources.ErrorMessage_UnauthenticatedInvalidAuthorisationHeader);
             }
 
             if (user == null)

--- a/ApiAuthenticationTests/Handlers/BasicAuthenticationHandlerTests.cs
+++ b/ApiAuthenticationTests/Handlers/BasicAuthenticationHandlerTests.cs
@@ -96,8 +96,8 @@ namespace ApiAuthenticationTests.Handlers
             //Assert
             var ex = Assert.ThrowsAsync<HttpException>(() => this._authenticationHandler.AuthenticateAsync());
             Assert.AreEqual(HttpStatusCode.Unauthorized, ex.StatusCode);
-            Assert.AreEqual(Resources.ErrorMessage_UnauthenticatedMissingAuthenticationHeader, ex.Message);
-            Assert.AreEqual(Resources.ErrorCode_UnauthenticatedMissingAuthenticationHeader, ex.ErrorCode);
+            Assert.AreEqual(Resources.ErrorMessage_UnauthenticatedMissingAuthorisationHeader, ex.Message);
+            Assert.AreEqual(Resources.ErrorCode_UnauthenticatedMissingAuthorisationHeader, ex.ErrorCode);
         }
 
         [Test]
@@ -118,8 +118,8 @@ namespace ApiAuthenticationTests.Handlers
             //Assert
             var ex = Assert.ThrowsAsync<HttpException>(() => this._authenticationHandler.AuthenticateAsync());
             Assert.AreEqual(HttpStatusCode.Unauthorized, ex.StatusCode);
-            Assert.AreEqual(Resources.ErrorMessage_UnauthenticatedInvalidAuthenticationHeader, ex.Message);
-            Assert.AreEqual(Resources.ErrorCode_UnauthenticatedInvalidAuthenticationHeader, ex.ErrorCode);
+            Assert.AreEqual(Resources.ErrorMessage_UnauthenticatedInvalidAuthorisationHeader, ex.Message);
+            Assert.AreEqual(Resources.ErrorCode_UnauthenticatedInvalidAuthorisationHeader, ex.ErrorCode);
         }
 
         [Test]

--- a/ApiSharedLibrary/Resources/Resources.Designer.cs
+++ b/ApiSharedLibrary/Resources/Resources.Designer.cs
@@ -117,18 +117,18 @@ namespace ApiSharedLibrary.Resources {
         /// <summary>
         ///   Looks up a localized string similar to 6789.
         /// </summary>
-        public static string ErrorCode_UnauthenticatedInvalidAuthenticationHeader {
+        public static string ErrorCode_UnauthenticatedInvalidAuthorisationHeader {
             get {
-                return ResourceManager.GetString("ErrorCode_UnauthenticatedInvalidAuthenticationHeader", resourceCulture);
+                return ResourceManager.GetString("ErrorCode_UnauthenticatedInvalidAuthorisationHeader", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to 5678.
         /// </summary>
-        public static string ErrorCode_UnauthenticatedMissingAuthenticationHeader {
+        public static string ErrorCode_UnauthenticatedMissingAuthorisationHeader {
             get {
-                return ResourceManager.GetString("ErrorCode_UnauthenticatedMissingAuthenticationHeader", resourceCulture);
+                return ResourceManager.GetString("ErrorCode_UnauthenticatedMissingAuthorisationHeader", resourceCulture);
             }
         }
         
@@ -205,7 +205,7 @@ namespace ApiSharedLibrary.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Authentication failed: The credentials received in the Authentication header were incorrect..
+        ///   Looks up a localized string similar to Authentication failed: The credentials received in the Authorisation header were incorrect..
         /// </summary>
         public static string ErrorMessage_UnauthenticatedIncorrectCredentials {
             get {
@@ -214,20 +214,20 @@ namespace ApiSharedLibrary.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Authentication failed: The request received contained an invalid Authentication header. Please try using Basic Authentication..
+        ///   Looks up a localized string similar to Authentication failed: The request received contained an invalid &apos;Authorization&apos; header. Please try using Basic Authentication..
         /// </summary>
-        public static string ErrorMessage_UnauthenticatedInvalidAuthenticationHeader {
+        public static string ErrorMessage_UnauthenticatedInvalidAuthorisationHeader {
             get {
-                return ResourceManager.GetString("ErrorMessage_UnauthenticatedInvalidAuthenticationHeader", resourceCulture);
+                return ResourceManager.GetString("ErrorMessage_UnauthenticatedInvalidAuthorisationHeader", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Authentication failed: The request received was missing an Authentication header. Please retry using Basic Authentication..
+        ///   Looks up a localized string similar to Authentication failed: The request received was missing an &apos;Authorization&apos; header. Please retry using Basic Authentication..
         /// </summary>
-        public static string ErrorMessage_UnauthenticatedMissingAuthenticationHeader {
+        public static string ErrorMessage_UnauthenticatedMissingAuthorisationHeader {
             get {
-                return ResourceManager.GetString("ErrorMessage_UnauthenticatedMissingAuthenticationHeader", resourceCulture);
+                return ResourceManager.GetString("ErrorMessage_UnauthenticatedMissingAuthorisationHeader", resourceCulture);
             }
         }
         

--- a/ApiSharedLibrary/Resources/Resources.resx
+++ b/ApiSharedLibrary/Resources/Resources.resx
@@ -135,10 +135,10 @@
   <data name="ErrorCode_UnauthenticatedIncorrectCredentials" xml:space="preserve">
     <value>7890</value>
   </data>
-  <data name="ErrorCode_UnauthenticatedInvalidAuthenticationHeader" xml:space="preserve">
+  <data name="ErrorCode_UnauthenticatedInvalidAuthorisationHeader" xml:space="preserve">
     <value>6789</value>
   </data>
-  <data name="ErrorCode_UnauthenticatedMissingAuthenticationHeader" xml:space="preserve">
+  <data name="ErrorCode_UnauthenticatedMissingAuthorisationHeader" xml:space="preserve">
     <value>5678</value>
   </data>
   <data name="ErrorCode_Validation" xml:space="preserve">
@@ -166,13 +166,13 @@
     <value>An internal server error occurred when mapping from the request DTO to the banking API request DTO.</value>
   </data>
   <data name="ErrorMessage_UnauthenticatedIncorrectCredentials" xml:space="preserve">
-    <value>Authentication failed: The credentials received in the Authentication header were incorrect.</value>
+    <value>Authentication failed: The credentials received in the Authorisation header were incorrect.</value>
   </data>
-  <data name="ErrorMessage_UnauthenticatedInvalidAuthenticationHeader" xml:space="preserve">
-    <value>Authentication failed: The request received contained an invalid Authentication header. Please try using Basic Authentication.</value>
+  <data name="ErrorMessage_UnauthenticatedInvalidAuthorisationHeader" xml:space="preserve">
+    <value>Authentication failed: The request received contained an invalid 'Authorization' header. Please try using Basic Authentication.</value>
   </data>
-  <data name="ErrorMessage_UnauthenticatedMissingAuthenticationHeader" xml:space="preserve">
-    <value>Authentication failed: The request received was missing an Authentication header. Please retry using Basic Authentication.</value>
+  <data name="ErrorMessage_UnauthenticatedMissingAuthorisationHeader" xml:space="preserve">
+    <value>Authentication failed: The request received was missing an 'Authorization' header. Please retry using Basic Authentication.</value>
   </data>
   <data name="ErrorMessage_Validation" xml:space="preserve">
     <value>One or more validation errors were found in the request.</value>


### PR DESCRIPTION
Quick resource file change + corresponding variable usages. I noticed the mistake as I was building the Postman collection.
Used the american spelling in the error message string itself as that's the actual name of the request header property, but I've used the british spelling everywhere else.