### PR TITLE
Model validation tweaks and bug fixes.

### DIFF
--- a/ApiSharedLibrary/Resources/Resources.Designer.cs
+++ b/ApiSharedLibrary/Resources/Resources.Designer.cs
@@ -304,6 +304,15 @@ namespace ApiSharedLibrary.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The paymentAmount must be a number greater than 0.00..
+        /// </summary>
+        public static string Validation_PaymentAmount {
+            get {
+                return ResourceManager.GetString("Validation_PaymentAmount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The transactionId must be in the format of a GUID - a 32 digit unique ID made up of hexadecimal characters separated by hyphens like so: 8-4-4-4-12..
         /// </summary>
         public static string Validation_TransactionId {

--- a/ApiSharedLibrary/Resources/Resources.resx
+++ b/ApiSharedLibrary/Resources/Resources.resx
@@ -198,6 +198,9 @@
   <data name="Validation_ExpirationYear" xml:space="preserve">
     <value>The expirationYear must not be in the past or more than 15 years in the future.</value>
   </data>
+  <data name="Validation_PaymentAmount" xml:space="preserve">
+    <value>The paymentAmount must be a number greater than 0.00.</value>
+  </data>
   <data name="Validation_TransactionId" xml:space="preserve">
     <value>The transactionId must be in the format of a GUID - a 32 digit unique ID made up of hexadecimal characters separated by hyphens like so: 8-4-4-4-12.</value>
   </data>

--- a/PaymentGatewayApi/Controllers/PaymentsController.cs
+++ b/PaymentGatewayApi/Controllers/PaymentsController.cs
@@ -5,12 +5,12 @@ using PaymentGatewayApi.Models.CustomAttributes.ActionFilters;
 using PaymentGatewayApi.Models.RequestEntities;
 using PaymentGatewayApi.Models.ResponseEntities;
 using PaymentGatewayApi.Services;
-using System;
 using System.Net;
 using System.Threading.Tasks;
 
 namespace PaymentGatewayApi.Controllers
 {
+    [Route("api/[controller]")]
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiVersion("1.0")]
     public class PaymentsController : ControllerBase
@@ -42,6 +42,7 @@ namespace PaymentGatewayApi.Controllers
             });
         }
 
+        [HttpGet]
         [HttpGet("{transactionid}")]
         [Authorize]
         [ServiceFilter(typeof(ModelValidationAttribute))]

--- a/PaymentGatewayApi/Mappers/DtoMapper.cs
+++ b/PaymentGatewayApi/Mappers/DtoMapper.cs
@@ -8,6 +8,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Text;
+using static PaymentGatewayApi.Models.Enums.PaymentEnums;
 
 namespace PaymentGatewayApi.Mappers
 {
@@ -70,7 +71,7 @@ namespace PaymentGatewayApi.Mappers
 
         public ProcessPaymentResponse MapBankApiPostResponseToDomainResponse(BankProcessPaymentResponseDto bankResponseDto)
         {
-            if (bankResponseDto == null)
+            if (bankResponseDto == null || bankResponseDto.TransactionId == null || !Enum.IsDefined(typeof(PaymentStatus), bankResponseDto.PaymentStatus))
             {
                 this._logger.LogError(Resources.Logging_DtoMapperNullInput, (typeof(BankProcessPaymentResponseDto).Name));
 

--- a/PaymentGatewayApi/Models/Enums/PaymentEnums.cs
+++ b/PaymentGatewayApi/Models/Enums/PaymentEnums.cs
@@ -25,13 +25,13 @@
             AmericanExpress,
         }
 
-        public enum PaymentStatus
+        public enum PaymentStatus //Starts at 1 so as not to default to 0 when the paymentStatus field is missing from the Bank API response.
         {
-            Success,
-            Pending,
-            FailedInsufficientFunds,
-            FailedIncorrectCardDetails,
-            FailedCardFrozen
+            Success = 1,
+            Pending = 2,
+            FailedInsufficientFunds = 3,
+            FailedIncorrectCardDetails = 4,
+            FailedCardFrozen = 5
         }
     }
 }

--- a/PaymentGatewayApi/Models/RequestEntities/ProcessPaymentRequestDto.cs
+++ b/PaymentGatewayApi/Models/RequestEntities/ProcessPaymentRequestDto.cs
@@ -38,6 +38,7 @@ namespace PaymentGatewayApi.Models.RequestEntities
 
         [JsonProperty("paymentAmount")]
         [Required]
+        [Range(minimum: 0.0, maximum: double.MaxValue, ErrorMessageResourceName = "Validation_PaymentAmount", ErrorMessageResourceType = typeof(Resources))]
         public decimal? PaymentAmount { get; set; }
 
         [JsonProperty("currency")]

--- a/PaymentGatewayApi/Startup.cs
+++ b/PaymentGatewayApi/Startup.cs
@@ -30,6 +30,12 @@ namespace PaymentGatewayApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddApiVersioning(options =>
+            {
+                options.AssumeDefaultVersionWhenUnspecified = true;
+                options.DefaultApiVersion = new ApiVersion(1, 0);
+                options.ReportApiVersions = true;
+            });
             services.AddMvcCore(options =>
             {
                 options.RespectBrowserAcceptHeader = true;
@@ -37,12 +43,6 @@ namespace PaymentGatewayApi
             }).AddJsonOptions(opts =>
             {
                 opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-            });
-            services.AddApiVersioning(options =>
-            {
-                options.AssumeDefaultVersionWhenUnspecified = true;
-                options.DefaultApiVersion = new ApiVersion(1, 0);
-                options.ReportApiVersions = true;
             });
             services.AddControllers();
 

--- a/PaymentGatewayApiTests/Mappers/DtoMapperTests.cs
+++ b/PaymentGatewayApiTests/Mappers/DtoMapperTests.cs
@@ -120,6 +120,86 @@ namespace PaymentGatewayApiTests.Mappers
                                             (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
         }
 
+        [Test]
+        public void MappingBankingApiResponseDtoToProcessPaymentResponseThrowsErrorIfTransactionIdIsMissing()
+        {
+            //Arrange
+            var bankingApiResponseDto = new BankProcessPaymentResponseDto()
+            {
+                TransactionId = null,
+                PaymentStatus = PaymentStatus.Success
+            };
+
+            //Act - see assertion.
+
+            //Assert
+            var ex = Assert.Throws<HttpException>(() => this._mapper.MapBankApiPostResponseToDomainResponse(bankingApiResponseDto));
+            Assert.AreEqual(HttpStatusCode.InternalServerError, ex.StatusCode);
+            Assert.AreEqual(Resources.ErrorMessage_MappingError_BankApiToPaymentApi, ex.Message);
+            Assert.AreEqual(Resources.ErrorCode_MappingError_BankApiToPaymentApi, ex.ErrorCode);
+
+            //Verify logging took place
+            this._logger.Verify(x => x.Log(LogLevel.Error,
+                                            It.IsAny<EventId>(),
+                                            It.IsAny<It.IsAnyType>(),
+                                            It.IsAny<Exception>(),
+                                            (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+        }
+
+        [Test]
+        public void MappingBankingApiResponseDtoToProcessPaymentResponseThrowsErrorIfPaymentStatusIsMissing()
+        {
+            //Arrange
+            var transactionId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+            var bankingApiResponseDto = new BankProcessPaymentResponseDto()
+            {
+                TransactionId = transactionId
+            };
+
+            //Act - see assertion.
+
+            //Assert
+            var ex = Assert.Throws<HttpException>(() => this._mapper.MapBankApiPostResponseToDomainResponse(bankingApiResponseDto));
+            Assert.AreEqual(HttpStatusCode.InternalServerError, ex.StatusCode);
+            Assert.AreEqual(Resources.ErrorMessage_MappingError_BankApiToPaymentApi, ex.Message);
+            Assert.AreEqual(Resources.ErrorCode_MappingError_BankApiToPaymentApi, ex.ErrorCode);
+
+            //Verify logging took place
+            this._logger.Verify(x => x.Log(LogLevel.Error,
+                                            It.IsAny<EventId>(),
+                                            It.IsAny<It.IsAnyType>(),
+                                            It.IsAny<Exception>(),
+                                            (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+        }
+
+        [TestCase(0)]
+        [TestCase(6)]
+        public void MappingBankingApiResponseDtoToProcessPaymentResponseThrowsErrorIfPaymentStatusIsOutsideKnownEnumRange(int paymentStatus)
+        {
+            //Arrange
+            var transactionId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+            var bankingApiResponseDto = new BankProcessPaymentResponseDto()
+            {
+                TransactionId = transactionId,
+                PaymentStatus = (PaymentStatus)paymentStatus
+            };
+
+            //Act - see assertion.
+
+            //Assert
+            var ex = Assert.Throws<HttpException>(() => this._mapper.MapBankApiPostResponseToDomainResponse(bankingApiResponseDto));
+            Assert.AreEqual(HttpStatusCode.InternalServerError, ex.StatusCode);
+            Assert.AreEqual(Resources.ErrorMessage_MappingError_BankApiToPaymentApi, ex.Message);
+            Assert.AreEqual(Resources.ErrorCode_MappingError_BankApiToPaymentApi, ex.ErrorCode);
+
+            //Verify logging took place
+            this._logger.Verify(x => x.Log(LogLevel.Error,
+                                            It.IsAny<EventId>(),
+                                            It.IsAny<It.IsAnyType>(),
+                                            It.IsAny<Exception>(),
+                                            (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+        }
+
 
         [Test]
         public void SuccessfullyMapsPaymentRetrievalRequestModelToBankingApiRequestDto()

--- a/PaymentGatewayApiTests/Models/RequestEntities/ProcessPaymentRequestDtoTests.cs
+++ b/PaymentGatewayApiTests/Models/RequestEntities/ProcessPaymentRequestDtoTests.cs
@@ -130,6 +130,47 @@ namespace PaymentGatewayApiTests.Models.RequestEntities
             Assert.AreEqual(shouldFailValidation, results.Any(result => result.MemberNames.Contains("ExpirationYear")));
         }
 
+        [TestCase(0.00, false)]
+        [TestCase(1.00, false)]
+        [TestCase(100.00, false)]
+        [TestCase(1000.00, false)]
+        [TestCase(10000.00, false)]
+        [TestCase(10000.00, false)]
+        [TestCase(100000.00, false)]
+        [TestCase(1000000.00, false)]
+        [TestCase(10000000.00, false)]
+        [TestCase(100000000.00, false)]
+        [TestCase(1000000000.00, false)]
+        [TestCase(10000000000.00, false)]
+        [TestCase(100000000000.00, false)]
+        [TestCase(1000000000000.00, false)]
+        [TestCase(10000000000000.00, false)]
+        [TestCase(-0.01, true)]
+        [TestCase(-0.001, true)]
+        [TestCase(-0.0001, true)]
+        [TestCase(-0.00001, true)]
+        [TestCase(-0.000001, true)]
+        [TestCase(-0.0000001, true)]
+        [TestCase(-0.00000001, true)]
+        [TestCase(-0.000000001, true)]
+        [TestCase(-0.0000000001, true)]
+        [TestCase(-0.00000000001, true)]
+        //The tests for the custom validation logic which require the current date are in the CustomAttributes folder.
+        public void ValidatePaymentAmount(decimal paymentAmount, bool shouldFailValidation)
+        {
+            //Arrange
+            var model = new ProcessPaymentRequestDto()
+            {
+                PaymentAmount = paymentAmount
+            };
+
+            //Act
+            var results = ModelValidator.ValidateModel(model);
+
+            //Assert
+            Assert.AreEqual(shouldFailValidation, results.Any(result => result.MemberNames.Contains("PaymentAmount")));
+        }
+
         [TestCase(0, false)] //British pounds
         [TestCase(1, false)] //US dollars
         [TestCase(2, false)] //Euros


### PR DESCRIPTION
- Do not allow a negative payment amount to be passed to the POST endpoint.
- Handle missing transaction ID or paymentStatus in POST response from Bank API.
- Allow version number to be ommitted from the API URL.
- Throw 400 when GET endpoint is called without a transaction ID